### PR TITLE
fix: change parameters widget to CodeEditor in ServiceBindings & ServiceInstances

### DIFF
--- a/extensions/service-management/servicebindings.yaml
+++ b/extensions/service-management/servicebindings.yaml
@@ -69,8 +69,8 @@ data:
       placeholder: spec.externalNamePlaceholder
     - path: spec.secretName
     - path: spec.parameters
-      widget: KeyValuePair
-      defaultExpanded: false
+      widget: CodeEditor
+      language: "'JSON'"
     - path: spec.parametersFrom
       widget: SimpleList
       defaultExpanded: true

--- a/extensions/service-management/serviceinstances.yaml
+++ b/extensions/service-management/serviceinstances.yaml
@@ -57,8 +57,8 @@ data:
     - path: spec.externalName
       placeholder: spec.externalNamePlaceholder
     - path: spec.parameters
-      widget: KeyValuePair
-      defaultExpanded: false
+      widget: CodeEditor
+      language: "'JSON'"
   general: |
     resource:
       kind: ServiceInstance


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- change parameters widget in SB to CodeEditor
- change parameters widget in SI to CodeEditor

**Related issue(s)**
Closes https://github.com/kyma-project/busola/issues/1650

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
