### PR TITLE
add trigger for sourceType in functions

### DIFF
--- a/extensions/serverless/functions.yaml
+++ b/extensions/serverless/functions.yaml
@@ -177,6 +177,7 @@ data:
         - Git Repository
       dynamicValue: '$exists(spec.source.gitRepository) ? "Git Repository" : "Inline"'
       name: header.sourceType
+      trigger: [sourceType]
     - simple: true
       type: string
       name: Language
@@ -208,6 +209,21 @@ data:
           language: '$contains($root.spec.runtime, "node") ? "javascript" : "python"'
           defaultExpanded: true
           subscribe:
+            sourceType: |-
+              $sourceType = 'Inline' ? $language = 'nodejs' ? $exists($root.metadata.creationTimestamp) ? $root.spec.source.inline.source : "module.exports = {
+                main: async function (event, context) {
+                  const message = `Hello World`
+                    + ` from the Kyma Function ${context['function-name']}`
+                    + ` running on ${context.runtime}!`;
+                  console.log(message);
+                  return message;
+                }
+              }" :
+              $language = 'python' ? $exists($root.metadata.creationTimestamp) ? $root.spec.source.inline.source : "def main(event, context):
+                  message = 'Hello World from the Kyma Function '+context['function-name']+' running on '+context['runtime']+ '!';
+                  print(message)
+                  return message" :
+              '' : ''
             language: |-
               $language = 'nodejs' ? $exists($root.metadata.creationTimestamp) ? $root.spec.source.inline.source : "module.exports = {
                 main: async function (event, context) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- add trigger for `sourceType` to fill in when source is Inline based on chosen runtime.

**Related issue(s)**
Closes https://github.com/kyma-project/busola/issues/2253
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
