### PR TITLE
add defaultExpanded for module wizard

### DIFF
--- a/extensions/wizards/module-wizard.yaml
+++ b/extensions/wizards/module-wizard.yaml
@@ -39,6 +39,7 @@ data:
           enum: '$distinct($moduleTemplates().items.spec.channel)'
         - widget: GenericList
           path: spec.modules
+          defaultExpanded: true
           children:
             - path: "[].name"
               required: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- we are adding by default empty module. when genericList is closed then first what the user is clicking is `add` which provides to have 2 empty modules in YAML.

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
