### PR TITLE
fix displaying link to docs without chosen channel

### DIFF
--- a/extensions/kyma/kyma.yaml
+++ b/extensions/kyma/kyma.yaml
@@ -112,11 +112,11 @@ data:
         - widget: Alert
           severity: information
           alert: '(
-            $linkToDocumentation := $filter($moduleTemplates().items, function($v) {$v.metadata.labels."operator.kyma-project.io/module-name" = $item.name and $v.spec.channel=$item.channel}).metadata.annotations."operator.kyma-project.io/doc-url";
+            $linkToDocumentation := $filter($moduleTemplates().items, function($v) {$v.metadata.labels."operator.kyma-project.io/module-name" = $item.name and ($v.spec.channel = $item.channel or $v.spec.channel = $parent.spec.channel)}).metadata.annotations."operator.kyma-project.io/doc-url";
             $count($linkToDocumentation) > 0 ? "Link to {{[documentation](" & $linkToDocumentation & ")}}" : "";
           )'
           visibility: '(
-            $linkToDocumentation := $filter($moduleTemplates().items, function($v) {$v.metadata.labels."operator.kyma-project.io/module-name" = $item.name and $v.spec.channel=$item.channel}).metadata.annotations."operator.kyma-project.io/doc-url";
+            $linkToDocumentation := $filter($moduleTemplates().items, function($v) {$v.metadata.labels."operator.kyma-project.io/module-name" = $item.name and ($v.spec.channel = $item.channel or $v.spec.channel = $root.spec.channel)}).metadata.annotations."operator.kyma-project.io/doc-url";
             $count($linkToDocumentation) > 0;
           )'
         - widget: Alert

--- a/extensions/wizards/module-wizard.yaml
+++ b/extensions/wizards/module-wizard.yaml
@@ -64,11 +64,11 @@ data:
             - widget: Alert
               severity: information
               alert: '(
-                $linkToDocumentation := $filter($moduleTemplates().items, function($v) {$v.metadata.labels."operator.kyma-project.io/module-name" = $item.name and $v.spec.channel = $item.channel}).metadata.annotations."operator.kyma-project.io/doc-url";
+                $linkToDocumentation := $filter($moduleTemplates().items, function($v) {$v.metadata.labels."operator.kyma-project.io/module-name" = $item.name and ($v.spec.channel = $item.channel or $v.spec.channel = $parent.spec.channel)}).metadata.annotations."operator.kyma-project.io/doc-url";
                 $count($linkToDocumentation) > 0 ? "Link to {{[documentation](" & $linkToDocumentation & ")}}" : "";
               )'
               visibility: '(
-                $linkToDocumentation := $filter($moduleTemplates().items, function($v) {$v.metadata.labels."operator.kyma-project.io/module-name" = $item.name and $v.spec.channel = $item.channel}).metadata.annotations."operator.kyma-project.io/doc-url";
+                $linkToDocumentation := $filter($moduleTemplates().items, function($v) {$v.metadata.labels."operator.kyma-project.io/module-name" = $item.name and $v.spec.channel = $item.channel or $v.spec.channel = $root.spec.channel}).metadata.annotations."operator.kyma-project.io/doc-url";
                 $count($linkToDocumentation) > 0;
               )'
             - widget: Alert

--- a/tests/support/exceptions.js
+++ b/tests/support/exceptions.js
@@ -8,6 +8,9 @@ Cypress.Commands.add('handleExceptions', () => {
       ) ||
       err.message.includes('ResizeObserver loop limit exceeded') ||
       err.message.includes(
+        'ResizeObserver loop completed with undelivered notifications',
+      ) ||
+      err.message.includes(
         "Cannot read properties of null (reading 'sendError')",
       ) ||
       err.message.includes(


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- we want to display link for docs without chosen channel for module.

**Related issue(s)**

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
